### PR TITLE
add eth_getTransactionCount to getaddressnounce mapped

### DIFF
--- a/pkg/eth/rpc_types.go
+++ b/pkg/eth/rpc_types.go
@@ -1285,7 +1285,13 @@ type (
 		Address string
 		Tag     string
 	}
+	GetTransactionCountResponse string
 )
+
+func (r *GetTransactionCountRequest) UnmarshalJSON(data []byte) error {
+	tmp := []interface{}{&r.Address, &r.Tag}
+	return json.Unmarshal(data, &tmp)
+}
 
 // ========== getstorage ============= //
 type (

--- a/pkg/kaon/jsonrpc.go
+++ b/pkg/kaon/jsonrpc.go
@@ -45,6 +45,7 @@ const (
 	MethodSendRawTx                   = "sendrawtransaction"
 	MethodGetStakingInfo              = "getstakinginfo"
 	MethodGetAddressBalance           = "getaddressbalance"
+	MethodGetAddressNounce            = "getaddressnounce"
 	MethodGetAddressUTXOs             = "getaddressutxos"
 	MethodCreateWallet                = "createwallet"
 	MethodLoadWallet                  = "loadwallet"

--- a/pkg/kaon/method.go
+++ b/pkg/kaon/method.go
@@ -248,12 +248,17 @@ func (m *Method) GetGasPrice(ctx context.Context) (result *big.Int, err error) {
 	return result, nil
 }
 
-// TODO: fixme, remove hardcode
-func (m *Method) GetTransactionCount(ctx context.Context, address string, status string) (*big.Int, error) {
-	// eventually might work this out to see if there's any transactions pending for an address in the mempool
-	// for now just always return 1
-	m.GetDebugLogger().Log("Message", "GetTransactionCount is hardcoded to one")
-	return big.NewInt(0x1), nil
+func (m *Method) GetTransactionCount(ctx context.Context, req *GetTransactionCountRequest) (resp *GetTransactionCountResponse, err error) {
+	if err := m.RequestWithContext(ctx, MethodGetAddressNounce, req, &resp); err != nil {
+		if m.IsDebugEnabled() {
+			m.GetDebugLogger().Log("function", "GetTransactionCount", "error", err)
+		}
+		return nil, err
+	}
+	if m.IsDebugEnabled() {
+		m.GetDebugLogger().Log("function", "GetTransactionCount", "request", marshalToString(req), "msg", "Successfully got getaddressnounce response")
+	}
+	return
 }
 
 func (m *Method) GetBlockHash(ctx context.Context, b *big.Int) (resp GetBlockHashResponse, err error) {

--- a/pkg/kaon/rpc_types.go
+++ b/pkg/kaon/rpc_types.go
@@ -2231,6 +2231,32 @@ func (request *GetStorageRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(params)
 }
 
+// =======getaddressnounce ============= //
+type (
+	/*
+		Arguments:
+		1. "address",	(string) The Kaon address
+		2. "blockNumber" (int | "latest", optional, default=null) The block number to start looking for logs. ()
+		Result: n (int) The integer of the number of transactions sent from an address
+	*/
+	GetTransactionCountRequest struct {
+		Address     string
+		BlockNumber interface{} `json:"blockNumber"`
+	}
+
+	GetTransactionCountResponse struct {
+		*big.Int
+	}
+)
+
+func (request *GetTransactionCountRequest) MarshalJSON() ([]byte, error) {
+	params := []interface{}{request.Address}
+	if request.BlockNumber != nil {
+		params = append(params, request.BlockNumber)
+	}
+	return json.Marshal(params)
+}
+
 // ======== getaddressbalance ========= //
 type (
 


### PR DESCRIPTION
eth_getTransactionCount was hardcoded to return 1
it is dangerous because this is a part of the nounce calculaton in Metamask and similar wallet providers